### PR TITLE
Theme text area handle

### DIFF
--- a/src/main/resources/io/jenkins/plugins/darktheme/theme.css
+++ b/src/main/resources/io/jenkins/plugins/darktheme/theme.css
@@ -79,6 +79,10 @@
   --header-search-border: var(--background-333);
   --input-hidden-password-bg-color: var(--input-color);
 
+  /* Text area handle */
+  --text-area-handle-border: var(--background-333);
+  --text-area-handle-bg-color: var(--text-area-handle-border);
+
   /* Pop out menus */
   --menu-bg-color: var(--background-333);
   --menu-text-color: var(--primary);


### PR DESCRIPTION
Requires https://github.com/jenkinsci/jenkins/pull/4843

Fixes https://github.com/jenkinsci/dark-theme-plugin/issues/103

<details>
<summary>Before</summary>

<img width="934" alt="Screenshot" src="https://user-images.githubusercontent.com/1831569/85206652-d65f0480-b323-11ea-8666-4f3c37ec01d1.png">

</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/21194782/87222413-539df800-c36b-11ea-91bb-7f8830694f0a.png)


</details>