### PR TITLE
Improve contrast for dark link colours

### DIFF
--- a/src/main/resources/io/jenkins/plugins/darktheme/theme.css
+++ b/src/main/resources/io/jenkins/plugins/darktheme/theme.css
@@ -39,7 +39,6 @@
   /* Links */
   --link-color: var(--primary);
   --link-visited-color: var(--primary);
-  --link-dark-color: var(--primary);
 
   /* Table */
   --bigtable-header-color: var(--background-black);


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/dark-theme-plugin/issues/88

<details>
<summary>Before</summary>

![image](https://user-images.githubusercontent.com/21194782/87223749-530b5e80-c377-11ea-99c6-7c17616f3e5d.png)


</details>

<details>
<summary>After</summary>

![image](https://user-images.githubusercontent.com/21194782/87223739-3a9b4400-c377-11ea-915a-bf6f1ecf44e8.png)

</details>

Thoughts @major-fire and @fqueiruga ?