### PR TITLE
Bump minimum version to 2.248

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <revision>0.0.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.246</jenkins.version>
+    <jenkins.version>2.248</jenkins.version>
     <java.level>8</java.level>
     <tagNameFormat>@{project.version}</tagNameFormat>
     <useBeta>true</useBeta>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <properties>
     <revision>0.0.3</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.240</jenkins.version>
+    <jenkins.version>2.246</jenkins.version>
     <java.level>8</java.level>
     <tagNameFormat>@{project.version}</tagNameFormat>
     <useBeta>true</useBeta>


### PR DESCRIPTION
Latest table changes aren't backwards compatible so bumping minimum version to the one which introduced them