### PR TITLE
Update minimum required version to 2.248 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This repository contains a dark theme for Jenkins.
 
-*Requires Jenkins >= 2.239*
+*Requires Jenkins >= 2.248*
 
 ## Usage
 


### PR DESCRIPTION
Commit a15c7f9 bumped the required version of Jenkins to **2.248**.
However, the README still stated, that the minimum required version
was **2.239** which caused a bit of confusion, as I was not able to
update the theme without updating Jenkins first.