### PR TITLE
Override --white, fixes 'more info' link in empty states

### DIFF
--- a/src/main/resources/io/jenkins/plugins/darktheme/theme.css
+++ b/src/main/resources/io/jenkins/plugins/darktheme/theme.css
@@ -7,6 +7,7 @@
   --very-light-grey: var(--dark-theme-bg-dark);
   --light-grey: var(--dark-theme-bg-333);
   --medium-grey: var(--dark-theme-bg-333);
+  --white: var(--dark-theme-bg-333);
 
   /* Text */
   --text-color: #c0c0c0;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/21194782/93903477-988dc580-fcf0-11ea-9ecb-ccb93029ec46.png)



After:
![image](https://user-images.githubusercontent.com/21194782/93903443-8f045d80-fcf0-11ea-8689-4625e1688db7.png)
