### PR TITLE
Use text color for dropdowns

### DIFF
--- a/src/main/frontend/main.scss
+++ b/src/main/frontend/main.scss
@@ -131,7 +131,7 @@
 
   /* Pop out menus */
   --menu-bg-color: var(--dark-theme-bg-medium);
-  --menu-text-color: var(--primary);
+  --menu-text-color: var(--text-color);
   --menu-selected-color: var(--dark-theme-bg-dark);
   --menu-box-shadow: none;
 


### PR DESCRIPTION
This PR adapts the changes from core, which dropped colors on breadcrumb links.

Also closes https://github.com/jenkinsci/dark-theme-plugin/issues/140