### PR TITLE
Set browser color scheme to 'dark'

### DIFF
--- a/src/main/frontend/main.scss
+++ b/src/main/frontend/main.scss
@@ -164,6 +164,11 @@
 
   /* Auto complete */
   --auto-complete-bg-color--prehighlight: var(--primary);
+
+  body {
+    // Render native browser elements in dark mode
+    color-scheme: dark;
+  }
 }
 
 @mixin codemirror-theme() {


### PR DESCRIPTION
So browsers will default to a 'light' color scheme for native elements, setting the `color-scheme` attribute to `dark` will use a dark color scheme instead.

https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme

**Before**
<img width="53" alt="image" src="https://user-images.githubusercontent.com/43062514/170800978-2d2d705b-63a5-4bf8-a798-7bad59d95bc8.png">

**After**
<img width="73" alt="image" src="https://user-images.githubusercontent.com/43062514/170800967-ec8e5597-c182-4b44-b54a-8c7ad6f14410.png">

Screenshots taken in Safari 15.4.
