### PR TITLE
Add backdrop variable for new Tippy tooltips

### DIFF
--- a/src/main/frontend/main.scss
+++ b/src/main/frontend/main.scss
@@ -70,9 +70,11 @@
 
   /* Tooltips */
   --tooltip-background: hsl(240, 6%, 23%);
-  --tooltip-box-shadow: inset 0 0 1px rgba(240, 240, 255, 0.1),
-                        0 10px 25px rgba(15, 15, 20, 0.5),
-                        0 7.5px 15px -15px rgba(0, 0, 0, 1);
+  --tooltip-backdrop-filter: contrast(0.6) saturate(4) brightness(0.4) blur(15px);
+  --tooltip-box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05), 
+                        0 0 8px 2px rgba(0, 0, 30, 0.05), 
+                        0 0 1px 1px rgba(0, 0, 20, 0.025), 
+                        0 10px 20px rgba(0, 0, 20, 0.15);
 
   /* Links */
   --link-color: #53c1ff;


### PR DESCRIPTION
<img width="201" alt="image" src="https://user-images.githubusercontent.com/43062514/196777843-abfdf885-0926-44c8-84cd-bc8046621fd8.png">

... so the new tooltips aren't blindingly white on dark theme. Uses the same styling as the prototype dark mode tooltips.