### PR TITLE
Add dropdown colors

### DIFF
--- a/src/main/frontend/main.scss
+++ b/src/main/frontend/main.scss
@@ -75,6 +75,13 @@
                         0 0 8px 2px rgba(0, 0, 30, 0.05), 
                         0 0 1px 1px rgba(0, 0, 20, 0.025), 
                         0 10px 20px rgba(0, 0, 20, 0.15);
+  
+  /* Dropdowns */
+  --dropdown-backdrop-filter: contrast(0.85) saturate(2) brightness(0.7) blur(20px);
+  --dropdown-box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+                         0 0 8px 2px rgba(0, 0, 30, 0.05),
+                         0 0 1px 1px rgba(0, 0, 20, 0.025),
+                         0 10px 20px rgba(0, 0, 20, 0.3);
 
   /* Links */
   --link-color: #53c1ff;


### PR DESCRIPTION
<img width="325" alt="image" src="https://user-images.githubusercontent.com/43062514/198856078-60bccf0f-e33a-48a1-ae71-2beb4263fd7c.png">

Adds the `backdrop-filter` and `box-shadow` vars necessary for [the search suggestions introduced in #7314](https://github.com/jenkinsci/jenkins/pull/7314).