### PR TITLE
Use Bootstrap dark theme in dark mode

### DIFF
--- a/src/main/java/io/jenkins/plugins/darktheme/DarkThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/darktheme/DarkThemeManagerFactory.java
@@ -14,6 +14,7 @@ public class DarkThemeManagerFactory extends ThemeManagerFactory {
     public static final String THEME_URL_NAME = "theme-dark";
     public static final String ACE_EDITOR_THEME = "tomorrow_night";
     public static final String PRISM_THEME = "tomorrow";
+    public static final String BOOTSTRAP_THEME = "dark";
 
     @DataBoundConstructor
     public DarkThemeManagerFactory() {
@@ -25,6 +26,7 @@ public class DarkThemeManagerFactory extends ThemeManagerFactory {
                 .withCssUrl(getCssUrl())
                 .withProperty("ace-editor", "theme", ACE_EDITOR_THEME)
                 .withProperty("prism-api", "theme", PRISM_THEME)
+                .withProperty("bootstrap", "theme", BOOTSTRAP_THEME)
                 .build();
     }
 

--- a/src/main/java/io/jenkins/plugins/darktheme/DarkThemeSystemManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/darktheme/DarkThemeSystemManagerFactory.java
@@ -22,6 +22,7 @@ public class DarkThemeSystemManagerFactory extends ThemeManagerFactory {
             .respectSystemAppearance()
             .withProperty("ace-editor", "theme-dark", ACE_EDITOR_THEME)
             .withProperty("prism-api", "theme-dark", PRISM_THEME)
+            .withProperty("bootstrap", "theme-dark", BOOTSTRAP_THEME)
             .build();
     }
 


### PR DESCRIPTION
Fixes #427 together with https://github.com/jenkinsci/bootstrap5-api-plugin/pull/253

### Testing done

Visually checked that warnings table looks OK
![image](https://github.com/jenkinsci/dark-theme-plugin/assets/1105305/af349837-f939-47e0-aae2-4ea4f4733cd4)
in dark-system and dark themes.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
