### PR TITLE
Darker color for search, highlight search help icon on hover

### DIFF
--- a/src/main/frontend/main.scss
+++ b/src/main/frontend/main.scss
@@ -48,7 +48,8 @@
   --header-link-color-active: var(--text-color);
   --header-bg-classic: #000;
   --search-bg: #4d545d;
-  --search-input-color: var(--text-color);
+  --search-input-color: rgb(200, 200, 204);
+  --header-link-bg-classic-hover: var(--text-color);
 
   /* Breadcrumbs */
   --breadcrumbs-bar-background: hsl(240, 6%, 9%, 0.8);


### PR DESCRIPTION
Fixes #205 by making the icon (and search field content) slightly darker by default and lighter on hover.

### Testing done
![image](https://github.com/jenkinsci/dark-theme-plugin/assets/1105305/16a7013d-7bbb-462a-a432-59b9df3d0acf)
![image](https://github.com/jenkinsci/dark-theme-plugin/assets/1105305/181ba65f-362e-46aa-911f-0cc3ed40dc8f)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
