### PR TITLE
Remove alert styles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <gitHubRepo>jenkinsci/dark-theme-plugin</gitHubRepo>
     <changelist>9999999-SNAPSHOT</changelist>
-    <jenkins.version>2.426.3</jenkins.version>
+    <jenkins.version>2.453</jenkins.version>
     <tagNameFormat>@{project.version}</tagNameFormat>
     <useBeta>true</useBeta>
     <node.version>18.20.0</node.version>

--- a/src/main/frontend/main.scss
+++ b/src/main/frontend/main.scss
@@ -21,20 +21,6 @@
   --call-to-action-text-color: var(--dark-theme-bg-medium);
   --call-to-action-link-color: var(--call-to-action-text-color);
 
-  /* Alerts */
-  --alert-success-text-color: #fff;
-  --alert-success-bg-color: #007e33;
-  --alert-success-border-color: var(--alert-success-bg-color);
-  --alert-info-text-color: #fff;
-  --alert-info-bg-color: #0099cc;
-  --alert-info-border-color: var(--alert-info-bg-color);
-  --alert-warning-text-color: #fff;
-  --alert-warning-bg-color: #ff8800;
-  --alert-warning-border-color: var(--alert-warning-bg-color);
-  --alert-danger-text-color: #fff;
-  --alert-danger-bg-color: #cc0000;
-  --alert-danger-border-color: var(--alert-danger-bg-color);
-
   /* Buttons */
   --btn-primary-bg: #53c1ff;
   --btn-secondary-bg: var(--dark-theme-bg-dark);


### PR DESCRIPTION
With https://github.com/jenkinsci/jenkins/pull/9115 it's no longer necessary for themes to set alert style variables - so this merge request removes them. 

Can either have the minimum Jenkins version be set to the weekly that contains the above MR or I can set the variables here with a comment that they can eventually be removed.

**Before 9115**
<img width="1086" alt="image" src="https://github.com/jenkinsci/dark-theme-plugin/assets/21194782/40f656af-34aa-44ed-933e-7100d423a297">

**After 9115**
<img width="907" alt="image" src="https://github.com/jenkinsci/dark-theme-plugin/assets/43062514/3ad7dbdd-d96a-4440-aa65-e13ff470efe9">

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
