### PR TITLE
Use Jenkins colour palette for Prism instead of `tomorrow`

### DIFF
--- a/src/main/java/io/jenkins/plugins/darktheme/DarkThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/darktheme/DarkThemeManagerFactory.java
@@ -13,7 +13,6 @@ public class DarkThemeManagerFactory extends ThemeManagerFactory {
     public static final String THEME_CSS = "theme.css";
     public static final String THEME_URL_NAME = "theme-dark";
     public static final String ACE_EDITOR_THEME = "tomorrow_night";
-    public static final String PRISM_THEME = "tomorrow";
     public static final String BOOTSTRAP_THEME = "dark";
     public static final String ENTRA_ID_THEME = "dark";
 
@@ -26,7 +25,6 @@ public class DarkThemeManagerFactory extends ThemeManagerFactory {
                 .withCssUrl(getCssUrl())
                 .withProperty("ace-editor", "theme", ACE_EDITOR_THEME)
                 .withProperty("entra-id", "theme", ENTRA_ID_THEME)
-                .withProperty("prism-api", "theme", PRISM_THEME)
                 .withProperty("bootstrap", "theme", BOOTSTRAP_THEME)
                 .build();
     }

--- a/src/main/java/io/jenkins/plugins/darktheme/DarkThemeSystemManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/darktheme/DarkThemeSystemManagerFactory.java
@@ -21,7 +21,6 @@ public class DarkThemeSystemManagerFactory extends ThemeManagerFactory {
                 .respectSystemAppearance()
                 .withProperty("ace-editor", "theme-dark", ACE_EDITOR_THEME)
                 .withProperty("entra-id", "theme-dark", ENTRA_ID_THEME)
-                .withProperty("prism-api", "theme-dark", PRISM_THEME)
                 .withProperty("bootstrap", "theme-dark", BOOTSTRAP_THEME)
                 .build();
     }


### PR DESCRIPTION
Following https://github.com/jenkinsci/prism-api-plugin/pull/161 it's no longer necessary for Jenkins themes to declare what theme Prism should use. This is due to the default Prism theme now using the default Jenkins colour palette for its colours, meaning that as long as themes override them Prism will pick them up automatically.

**Before**
![image](https://github.com/jenkinsci/dark-theme-plugin/assets/43062514/c141b3dc-d977-4508-b7a5-9692b557adb4)

**After**
![image](https://github.com/jenkinsci/dark-theme-plugin/assets/43062514/9720af74-a7b4-40db-85b9-790d8a73bbd5)

### Testing done

* Prism looks as expected

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
