### PR TITLE
fix: render dark scrollbars in dark mode

### DIFF
--- a/src/main/frontend/main.scss
+++ b/src/main/frontend/main.scss
@@ -174,10 +174,8 @@
   --card-border-color--hover: var(--card-border-color);
   --card-border-color--active: var(--card-border-color);
 
-  body {
-    // Render native browser elements in dark mode
-    color-scheme: dark;
-  }
+  // Render native browser elements in dark mode
+  color-scheme: dark;
 }
 
 @mixin codemirror-theme() {


### PR DESCRIPTION
Currently, scrollbars aren't dark in Chrome:

![image](https://github.com/jenkinsci/dark-theme-plugin/assets/1770529/d5933219-1634-4de7-b224-6eaa83272dcf)

### Testing done
with this change it will look like this:

![image](https://github.com/jenkinsci/dark-theme-plugin/assets/1770529/ff5ba689-10c4-4e8f-aee8-a508a95a5362)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
