### PR TITLE
Don't use a translucent color for cards/tables/tabs

### DIFF
--- a/src/main/frontend/main.scss
+++ b/src/main/frontend/main.scss
@@ -90,12 +90,8 @@
                       0 10px 20px rgba(0, 0, 20, 0.3);
 
   /* Table */
-  --table-background: hsla(240, 25%, 75%, 0.04);
-  --table-border-color: hsla(240, 25%, 75%, 0.02);
-
-  table {
-    background-clip: padding-box;
-  }
+  --table-background: var(--card-background);
+  --table-border-color: var(--card-border-color);
 
   /* Deprecated */
   --bigtable-header-bg: var(--dark-theme-bg-black);
@@ -111,12 +107,12 @@
   --pane-header-color: var(--dark-theme-bg-black);
 
   /* Tab bar */
-  --tabs-background: hsla(240, 25%, 75%, 0.04);
+  --tabs-background: var(--card-background);
   --tabs-item-background: transparent;
   --tabs-item-background--hover: rgba(255, 255, 255, 0.05);
   --tabs-item-background--active: rgba(255, 255, 255, 0.1);
   --tabs-item-background--selected: rgba(255, 255, 255, 0.05);
-  --tabs-border-color: hsla(240, 25%, 75%, 0.02);
+  --tabs-border-color: var(--card-border-color);
 
   /* Side panel */
   --panel-header-bg-color: var(--dark-theme-bg-black);
@@ -167,10 +163,10 @@
   --auto-complete-bg-color--prehighlight: var(--accent-color);
 
   /* Card */
-  --card-background: hsla(240, 25%, 75%, 0.04);
-  --card-background--hover: hsla(240, 25%, 75%, 0.06);
-  --card-background--active: hsla(240, 25%, 75%, 0.08);
-  --card-border-color: hsla(240, 25%, 75%, 0.02);
+  --card-background: hsl(240, 6%, 15%);
+  --card-background--hover: hsl(240, 6%, 17.5%);
+  --card-background--active: hsl(240, 6%, 20%);
+  --card-border-color: hsl(240, 6%, 16.5%);
   --card-border-color--hover: var(--card-border-color);
   --card-border-color--active: var(--card-border-color);
 


### PR DESCRIPTION
Small one to stop using translucent colors for cards/tables/tabs. This isn't really an issue in 'core' but in the Design Library the components can look a little odd when overlaying a colorful background (the color bleeds through). There shouldn't be any differences in 'core', apart from perhaps an unnoticeable hue change.

**Before**
<img width="1104" alt="image" src="https://github.com/user-attachments/assets/0752a211-dc48-4919-93c5-5ddaac2df58d">

**After**
<img width="1114" alt="image" src="https://github.com/user-attachments/assets/257a1793-ead1-4bf3-8b9a-f5098e20f41e">


### Testing done

* Cards/tables/tabs look as expected

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
