### PR TITLE
Stop testing Java 11

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.config text eol=lf
+*.java text eol=lf
+*.jelly text eol=lf
+*.sh text eol=lf
+*.xml text eol=lf
+*.yml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-*.config text eol=lf
-*.java text eol=lf
-*.jelly text eol=lf
-*.sh text eol=lf
-*.xml text eol=lf
-*.yml text eol=lf

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-        [ platform: 'windows', jdk: '17' ],
+        [ platform: 'linux', jdk: '17' ],
         [ platform: 'linux', jdk: '21' ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-        [ platform: "linux", jdk: "11" ],
-        [ platform: 'linux', jdk: '17' ],
+        [ platform: 'windows', jdk: '17' ],
         [ platform: 'linux', jdk: '21' ]
 ])


### PR DESCRIPTION
## Stop testing Java 11

Jenkins stopped supporting Java 11 with the release of Jenkins 2.463 (weekly) and Jenkins 2.479.1 (LTS).  Most plugins stopped spending ci.jenkins.io time to run tests that are specific to Java 11.

Let's save money and time by removing the Java 11 test configuration.  It has not found any issues that are not also found with Java 17 and Java 21.

Jenkins plugin BOM still tests with Java 11 on older lines (currently 2.452.x and 2.462.x) and the plugin build will continue to generate Java 11 byte code until the parent pom is upgraded to 5.x and the minimum Jenkins version is upgraded to 2.479.1.

Switch to test Windows with Java 17 since that matches the plugin archetype.

Explicitly declares the file types of source files to avoid the git client plugin bug that performs a checkout with Windows line terminators.  That causes spotless on Windows to reformat the source code to use Windows line terminators.  This is another instance of the git client plugin bug that was reported by @jtnord in:

* https://github.com/jenkins-infra/helpdesk/issues/3865

Unfortunately, the git client plugin maintainer (me) has not fixed that bug yet.

### Testing done

None.  Rely on ci.jenkins.io to test the pull request.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
