### PR TITLE
feat: add fallbacks to supports for browser

### DIFF
--- a/src/main/frontend/main.scss
+++ b/src/main/frontend/main.scss
@@ -13,7 +13,10 @@
   --light-grey: var(--dark-theme-bg-medium);
   --medium-grey: var(--dark-theme-bg-medium-grey);
 
-  --accent-color: color(display-p3 0.43 0.757 1);
+  --accent-color: #53c1ff;
+  @supports (color: color(display-p3 0 0 0)) {
+    --accent-color: color(display-p3 0.43 0.757 1);
+  }
 
   /* Text */
   --text-color: rgb(250, 250, 255);


### PR DESCRIPTION
fix #585 

### Testing done

In dark mode buttons are not shown as issue describe so , I added fallbacks in color 
because in some browser `display-p3` not supports so added fallbacks if not supports then default color `#53c1ff` supports and e can see color.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

