### PR TITLE
Fix mixed content by using relative CSS URL in DarkThemeManagerFactory

### DIFF
--- a/src/main/java/io/jenkins/plugins/darktheme/DarkThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/darktheme/DarkThemeManagerFactory.java
@@ -22,7 +22,7 @@ public class DarkThemeManagerFactory extends ThemeManagerFactory {
     @Override
     public Theme getTheme() {
         return Theme.builder()
-                .withCssUrl(getCssUrl())
+                .withCssUrl("/" + THEME_URL_NAME + "/" + THEME_CSS)
                 .withProperty("ace-editor", "theme", ACE_EDITOR_THEME)
                 .withProperty("entra-id", "theme", ENTRA_ID_THEME)
                 .withProperty("bootstrap", "theme", BOOTSTRAP_THEME)


### PR DESCRIPTION
This PR fixes a mixed content issue when Jenkins is accessed over HTTP while the Jenkins URL in the system configuration is set to HTTPS. In this scenario, the theme CSS was always requested via an absolute https:// URL, causing the browser to block the request when the page itself was loaded over HTTP.