### PR TITLE
Use context-path-relative URL for theme CSS

### DIFF
--- a/src/main/java/io/jenkins/plugins/darktheme/DarkThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/darktheme/DarkThemeManagerFactory.java
@@ -7,6 +7,8 @@ import io.jenkins.plugins.thememanager.ThemeManagerFactory;
 import io.jenkins.plugins.thememanager.ThemeManagerFactoryDescriptor;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest2;
 
 public class DarkThemeManagerFactory extends ThemeManagerFactory {
 
@@ -18,6 +20,21 @@ public class DarkThemeManagerFactory extends ThemeManagerFactory {
 
     @DataBoundConstructor
     public DarkThemeManagerFactory() {}
+
+    /**
+     * Returns a context-path-relative CSS URL so the theme works regardless of
+     * which host/port the user accesses Jenkins through (e.g. bypassing a
+     * reverse proxy). The parent implementation uses {@code Jenkins.get().getRootUrl()}
+     * which always returns the globally configured URL.
+     */
+    @Override
+    public String getCssUrl() {
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
+        if (req != null) {
+            return req.getContextPath() + "/" + THEME_URL_NAME + "/" + THEME_CSS;
+        }
+        return super.getCssUrl();
+    }
 
     @Override
     public Theme getTheme() {


### PR DESCRIPTION
Problem

When accessing Jenkins bypassing the configured reverse proxy (e.g. via an internal http://hostname:8080), the dark theme CSS fails to load (in case of my IP was not whitelisted on the main jenkins endpoint). The <link> tag in the page header points to the globally configured Jenkins URL (the reverse proxy), while all other CSS resources (adjuncts) use paths relative to the current request and load correctly.

For example, when accessing http://build-jenkins-int.example.com:8080 while the external https://build-jenkins.example.com is not accessible due to corporate restrictions:

 - ❌ Theme CSS: https://build-jenkins.example.com/theme-dark/theme.css — unreachable
 - ✅ Other CSS: http://build-jenkins-int.example.com:8080/adjuncts/.../main.css — works

Root cause

ThemeManagerFactory.getCssUrl() (from the theme-manager plugin) builds an absolute URL using Jenkins.get().getRootUrl(), which always returns the globally configured Jenkins URL regardless of how the user actually accesses the instance. This is unlike adjuncts/Stapler resources which use the request's context path.

Fix

Override getCssUrl() in DarkThemeManagerFactory to build the CSS URL from Stapler.getCurrentRequest2().getContextPath() instead of the global root URL. This produces a context-path-relative URL (e.g. /theme-dark/theme.css) that the browser resolves against the current host, making the theme work regardless of the access method.

Falls back to the parent implementation (Jenkins.get().getRootUrl()) when no Stapler request is available (e.g. during JCasC export or other non-HTTP contexts).



<!-- Please describe your pull request here. -->

### Testing done

All existing tests pass (JCasC configuration/export tests, InjectedTest, SpotBugs, Spotless).
The compiled HPI was installed to the affected jenkins instance and tested. 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
